### PR TITLE
Allow user to specify number of concurrent requests

### DIFF
--- a/src/StatusAlert.tsx
+++ b/src/StatusAlert.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Alert from '@mui/material/Alert'
 import LinearProgress from '@mui/material/LinearProgress'
 
@@ -15,7 +15,7 @@ export type StatusAlertProps = {
     alertType?: AlertType
 }
 
-export type AlertType = "error" | "success" | "info" | undefined
+export type AlertType = "error" | "success" | "info" | "warning" | undefined
 
 /**
  * Renders different indicators based on status.
@@ -37,4 +37,19 @@ export function StatusAlert({ loading, msg, alertType }: StatusAlertProps) {
         )
     }
     return (<></>)
+}
+
+export type StatusAlertSetter = (msg: string, alertType: AlertType) => void;
+
+export function useStatusAlert(msg: string, alertType: AlertType): [StatusAlertProps, StatusAlertSetter] {
+    const [msgState, setMsgState] = useState(msg)
+    const [alertTypeState, setAlertTypeState] = useState(alertType)
+    const setStatusAlert = (newMsg: string, newAlertType: AlertType) => {
+        setMsgState(newMsg)
+        setAlertTypeState(newAlertType)
+    }
+    return [{
+        msg: msgState,
+        alertType: alertTypeState,
+    }, setStatusAlert]
 }

--- a/src/arcgis.ts
+++ b/src/arcgis.ts
@@ -121,9 +121,6 @@ export class QueryResults {
         this.totalCount = 0
     }
 
-    /**
-     * Initializes paginator. If where string changes, it will reload objectIds according to new where clause
-     */
     private initialize = async (): Promise<void> => {
         if (this.initialized) {
             return

--- a/src/formats/geojson.ts
+++ b/src/formats/geojson.ts
@@ -28,13 +28,16 @@ type FeatureCollection = {
     }[]
 }
 
+export const DEFAULT_CONCURRENT_REQUESTS = 2
+export const MAX_CONCURRENT_REQUESTS = 20
+
 export class GeojsonDownloader {
     featuresWritten = 0
     onWrite: (featuresWritten: number) => void
     constructor(onWrite: (_: number) => void) {
         this.onWrite = onWrite
     }
-    download = async (results: QueryResults, fileHandle: FileSystemFileHandle, outFields: string[]) => {
+    download = async (results: QueryResults, fileHandle: FileSystemFileHandle, outFields: string[], numConcurrent: number) => {
         const layer = results.getLayer()
         if (!layer) {
             throw new Error("layer not defined")
@@ -55,8 +58,7 @@ export class GeojsonDownloader {
                 }
             })
         // Combine those callables into chunks
-        const chunkSize = 2
-        const callableChunks = chunk(getFeaturesCallables, chunkSize)
+        const callableChunks = chunk(getFeaturesCallables, numConcurrent)
         for (let i = 0; i < callableChunks.length; i++) {
             if (i !== 0) {
                 await writer.write(",")


### PR DESCRIPTION
Made StatusAlert easier to work with by adding useStatusAlert() function
that wraps useState()