### PR TITLE
Concurrent requests are truly concurrent now

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "clipboard-copy": "^4.0.1",
     "comlink": "^4.3.1",
     "esri-loader": "^3.3.0",
+    "fastq": "^1.13.0",
     "gdal3.js": "^1.0.1",
     "import": "^0.0.6",
     "nth-check": "2.0.1",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,0 @@
-export const chunk = <T>(arr: T[], size: number): T[][] =>
-    [...Array(Math.ceil(arr.length / size))].map((_, i) =>
-        arr.slice(size * i, size + size * i)
-    );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4597,7 +4597,7 @@ fastest-levenshtein@^1.0.12:
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
   integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
 
-fastq@^1.6.0:
+fastq@^1.13.0, fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
   integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==


### PR DESCRIPTION
Instead of batching up a "chunk" of requests and waiting for them all to
resolve, this instead sets up numConcurrent "workers" via fastq that
will start on the next page as soon as a worker is free to do so. This
should avoid the problem of sending many fetches all at once, as well as
generally speeding up operation