### PR TITLE
Fix filename check when creating output zip file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "leaflet": "^1.9.3",
         "material-ui-popup-state": "^5.0.9",
         "nth-check": "2.1.1",
+        "path-browserify": "^1.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-github-btn": "^1.4.0",
@@ -10524,6 +10525,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -21405,6 +21411,11 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
+    },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "path-exists": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "leaflet": "^1.9.3",
     "material-ui-popup-state": "^5.0.9",
     "nth-check": "2.1.1",
+    "path-browserify": "^1.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-github-btn": "^1.4.0",


### PR DESCRIPTION
Fixes #76.

In some cases, the Gdal output file isn't just `${layerName}.${extension}`. (This problem originally came up when there was a period in the layer name, but there may be other such cases.)

Anyway, Gdal actually tells us the name of one of the files it output for the last ogr2ogr command, so use that to pick out the output files to zip up.